### PR TITLE
Fix wrong memmove size in unescaping

### DIFF
--- a/readtags.c
+++ b/readtags.c
@@ -419,6 +419,12 @@ static void parseTagLine (tagFile *file, tagEntry *const entry)
 	{
 		*tab = '\0';
 	}
+
+	/* When unescaping, the input string becomes shorter.
+	 * e.g. \t occupies two bytes on the tag file.
+	 * It is converted to 0x9 and occupies one byte.
+	 * memmove called here for shortening the line
+	 * buffer. */
 	while (*p != '\0')
 	{
 		const char *next = p;
@@ -430,7 +436,8 @@ static void parseTagLine (tagFile *file, tagEntry *const entry)
 		p_len -= skip;
 		if (skip > 1)
 		{
-			memmove (p, next, p_len);
+			/* + 1 is for moving the area including the last '\0'. */
+			memmove (p, next, p_len + 1);
 			tab -= skip - 1;
 		}
 	}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,6 +4,8 @@ TESTS = \
 	test-api-tagsFind \
 	test-api-tagsFirstPseudoTag \
 	\
+	test-fix-unescaping \
+	\
 	$(NULL)
 
 check_PROGRAMS = \
@@ -11,6 +13,8 @@ check_PROGRAMS = \
 	test-api-tagsOpen \
 	test-api-tagsFind \
 	test-api-tagsFirstPseudoTag \
+	\
+	test-fix-unescaping \
 	\
 	$(NULL)
 
@@ -35,3 +39,7 @@ test_api_tagsFirstPseudoTag = test-api-tagsFirstPseudoTag.c
 test_api_tagsFirstPseudoTag_DEPENDENCIES = $(DEPS)
 EXTRA_DIST += ptag-sort-no.tags
 EXTRA_DIST += ptag-sort-yes.tags
+
+test_fix_unescaping = test-fix-unescaping.c
+test_fix_unescaping_DEPENDENCIES = $(DEPS)
+EXTRA_DIST += unescaping.tags

--- a/tests/test-fix-unescaping.c
+++ b/tests/test-fix-unescaping.c
@@ -1,0 +1,100 @@
+/*
+*   Copyright (c) 2020, Masatake YAMATO
+*
+*   This source code is released into the public domain.
+*
+*   Testing the fix for handling unescaping
+*/
+
+#include "readtags.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define NEXT()										\
+	r = tagsNext (t, &e);							\
+	if (r != TagSuccess)							\
+	{												\
+		fprintf (stderr, "error in tagsNext\n");	\
+		return 1;									\
+	}												\
+	do {} while (0)
+
+#define CHECK(EXP,FIELD)												\
+	if (strcmp (EXP, e.FIELD) != 0)										\
+	{																	\
+		fprintf (stderr, "unexpected " #FIELD "(expected: %s, actual: %s) in tagsFirst\n", \
+				 EXP, e.FIELD);											\
+		return 1;														\
+	} \
+	do {} while (0)
+
+int
+main (void)
+{
+	char *srcdir = getenv ("srcdir");
+	if (srcdir)
+	{
+		if (chdir (srcdir) == -1)
+		{
+			perror ("chdir");
+			return 99;
+		}
+	}
+
+	tagFile *t;
+	tagFileInfo info;
+
+	const char *tags0 = "./unescaping.tags";
+	t = tagsOpen (tags0, &info);
+	if (t == NULL
+		|| info.status.opened == 0)
+	{
+		fprintf (stderr, "unexpected result (t: %p, opened: %d)\n",
+				 t, info.status.opened);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	tagEntry e;
+	tagResult r;
+
+	r = tagsFirst (t, &e);
+	if (r != TagSuccess)
+	{
+		fprintf (stderr, "error in tagsFirst\n");
+		return 1;
+	}
+	CHECK ("aa", name);
+	CHECK ("main/Makefile", file);
+	CHECK ("/^%:$/", address.pattern);
+	CHECK ("t", kind);
+
+	NEXT ();
+	CHECK ("\taa", name);
+	CHECK ("parsers/Makefile", file);
+	CHECK ("/^%:$/", address.pattern);
+	CHECK ("t", kind);
+
+	NEXT ();
+	CHECK ("bb", name);
+	CHECK ("main/Makefile", file);
+	CHECK ("/^%:$/", address.pattern);
+	CHECK ("t", kind);
+
+	NEXT ();
+	CHECK ("\\\aa", name);
+	CHECK ("parsers/cxx/Makefile", file);
+	CHECK ("/^%:$/", address.pattern);
+	CHECK ("t", kind);
+
+	if (r != TagSuccess)
+	{
+		fprintf (stderr, "error in tagsClose\n");
+		return 1;
+	}
+
+	return 0;
+}

--- a/tests/unescaping.tags
+++ b/tests/unescaping.tags
@@ -1,0 +1,13 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/8d952eba/
+aa	main/Makefile	/^%:$/;"	t
+\taa	parsers/Makefile	/^%:$/;"	t
+bb	main/Makefile	/^%:$/;"	t
+\\\aa	parsers/cxx/Makefile	/^%:$/;"	t


### PR DESCRIPTION
When doing memmove to shorten the input line buffer, the last null
byte (C string terminator) was not considered.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>