### PR TITLE
Add an extra guard condtion in unescaping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ tests/*.trs
 tests/test-api-tagsFind
 tests/test-api-tagsFirstPseudoTag
 tests/test-api-tagsOpen
+tests/test-fix-null-deref
+tests/test-fix-unescaping

--- a/readtags.c
+++ b/readtags.c
@@ -438,7 +438,8 @@ static void parseTagLine (tagFile *file, tagEntry *const entry)
 		{
 			/* + 1 is for moving the area including the last '\0'. */
 			memmove (p, next, p_len + 1);
-			tab -= skip - 1;
+			if (tab)
+				tab -= skip - 1;
 		}
 	}
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,6 +5,7 @@ TESTS = \
 	test-api-tagsFirstPseudoTag \
 	\
 	test-fix-unescaping \
+	test-fix-null-deref \
 	\
 	$(NULL)
 
@@ -15,6 +16,7 @@ check_PROGRAMS = \
 	test-api-tagsFirstPseudoTag \
 	\
 	test-fix-unescaping \
+	test-fix-null-deref \
 	\
 	$(NULL)
 
@@ -43,3 +45,7 @@ EXTRA_DIST += ptag-sort-yes.tags
 test_fix_unescaping = test-fix-unescaping.c
 test_fix_unescaping_DEPENDENCIES = $(DEPS)
 EXTRA_DIST += unescaping.tags
+
+test_fix_null_deref = test-fix-null-deref.c
+test_fix_null_deref_DEPENDENCIES = $(DEPS)
+EXTRA_DIST += null-deref.tags

--- a/tests/null-deref.tags
+++ b/tests/null-deref.tags
@@ -1,0 +1,10 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/8d952eba/
+\x21a

--- a/tests/test-fix-null-deref.c
+++ b/tests/test-fix-null-deref.c
@@ -1,0 +1,50 @@
+/*
+*   Copyright (c) 2020, Masatake YAMATO
+*
+*   This source code is released into the public domain.
+*
+*   Testing the guard condition for NULL pointer dereference
+*/
+
+#include "readtags.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int
+main (void)
+{
+	char *srcdir = getenv ("srcdir");
+	if (srcdir)
+	{
+		if (chdir (srcdir) == -1)
+		{
+			perror ("chdir");
+			return 99;
+		}
+	}
+
+	tagFile *t;
+	tagFileInfo info;
+
+	const char *tags0 = "./null-deref.tags";
+	t = tagsOpen (tags0, &info);
+	if (t == NULL
+		|| info.status.opened == 0)
+	{
+		fprintf (stderr, "unexpected result (t: %p, opened: %d)\n",
+				 t, info.status.opened);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	tagEntry e;
+	tagResult r;
+
+	/* Without fix, this program crashes in tagsFirst(). */
+	tagsFirst (t, &e);
+	tagsClose (t);
+	return 0;
+}

--- a/tests/test-fix-unescaping.c
+++ b/tests/test-fix-unescaping.c
@@ -90,6 +90,7 @@ main (void)
 	CHECK ("/^%:$/", address.pattern);
 	CHECK ("t", kind);
 
+	r = tagsClose(t);
 	if (r != TagSuccess)
 	{
 		fprintf (stderr, "error in tagsClose\n");


### PR DESCRIPTION
This change is for avoiding crashing when reading a broken tags file.