### PR TITLE
fix the way to unescape extension fields

### DIFF
--- a/readtags.c
+++ b/readtags.c
@@ -340,7 +340,8 @@ static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 								  char *const string)
 {
 	char *p = string;
-	size_t q_len = strlen (p);
+	char *tail = string + (string? strlen(string):0);
+	size_t q_len;
 
 	while (p != NULL  &&  *p != '\0')
 	{
@@ -364,6 +365,8 @@ static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 				const int key_len = colon - key;
 				*colon = '\0';
 
+				q_len = tail - q;
+
 				/* Unescaping */
 				while (*q != '\0')
 				{
@@ -380,6 +383,8 @@ static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 						memmove (q, next, q_len + 1);
 						if (p)
 							p -= skip - 1;
+						if (tail != string)
+							tail -= skip - 1;
 					}
 				}
 

--- a/tests/test-fix-unescaping.c
+++ b/tests/test-fix-unescaping.c
@@ -155,6 +155,13 @@ main (void)
 	CHECK ("S", kind);
 	CHECK_X ("scope", "section:level2+");
 
+	NEXT ();
+	CHECK ("ClassFour", name);
+	CHECK ("input.php", file);
+	CHECK ("/^  use NS2\\\\{NS30 as NameSpaceTreePointO, NS31\\\\Cls4 as ClassFour};$/", address.pattern);
+	CHECK ("a", kind);
+	CHECK_X ("typeref", "unknown:NS2\\NS31\\Cls4");
+
 	r = tagsClose(t);
 	if (r != TagSuccess)
 	{

--- a/tests/unescaping.tags
+++ b/tests/unescaping.tags
@@ -17,3 +17,4 @@ level2	input.rst	/^level2$/;"	s	scope:chapter:\x01level1
 \x21level1+	input.rst	/^!level1+$/;"	c
 level2+	input.rst	/^level2+$/;"	s	scope:chapter:!level1+
 \x02level3+\x04	input.rst	/^level3+$/;"	S	scope:section:level2+
+ClassFour	input.php	/^  use NS2\\{NS30 as NameSpaceTreePointO, NS31\\Cls4 as ClassFour};$/;"	a	typeref:unknown:NS2\\NS31\\Cls4


### PR DESCRIPTION
988f5ba29e0cf8ca95931f4db66c426c048d0f2c considers only
the field current reading when shifting the contents with
memmove.

In this change, do memmove whole contents on the rest of the line
buffer.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>