### PR TITLE
Use "unsigned char" instead of "char" when comparing byte sequences

### DIFF
--- a/readtags.c
+++ b/readtags.c
@@ -113,7 +113,7 @@ static int xdigitValue (char digit)
  */
 static int readTagCharacter (const char **s)
 {
-	int c = **s;
+	int c = **(const unsigned char **)s;
 
 	(*s)++;
 
@@ -160,7 +160,7 @@ static int taguppercmp (const char *s1, const char *s2)
 	int c1, c2;
 	do
 	{
-		c1 = *s1++;
+		c1 = (unsigned char)*s1++;
 		c2 = readTagCharacter (&s2);
 
 		result = toupper (c1) - toupper (c2);
@@ -174,7 +174,7 @@ static int tagnuppercmp (const char *s1, const char *s2, size_t n)
 	int c1, c2;
 	do
 	{
-		c1 = *s1++;
+		c1 = (unsigned char)*s1++;
 		c2 = readTagCharacter (&s2);
 
 		result = toupper (c1) - toupper (c2);
@@ -188,7 +188,7 @@ static int tagcmp (const char *s1, const char *s2)
 	int c1, c2;
 	do
 	{
-		c1 = *s1++;
+		c1 = (unsigned char)*s1++;
 		c2 = readTagCharacter (&s2);
 
 		result = c1 - c2;


### PR DESCRIPTION
The original bug was found when developing Juila parser in u-ctags
repo[1].  When searching a tag name "α", readtags reported nothing
though an entry for "α" was in the tags file used for testing
the Julia parser.

"α" is {206, 177} as a byte sequence.

However, when comparing bytes in strings, libreadtags used (singed)
char type. In the case "α" was {-50, -79}.  Using {-50, -79} for
comparison, the binary search didn't work as we expected.

The test for this change will be done in u-ctag side.

[1] https://github.com/universal-ctags/ctags/pull/2654

Signed-off-by: Masatake YAMATO <yamato@redhat.com>