### PR TITLE
build-sys: enable gcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .deps
 .libs
+*.gcda
+*.gcno
+*.gcov
 *.la
 *.lo
 *.o

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@ AM_CFLAGS=-Wall
 
 lib_LTLIBRARIES    = libreadtags.la
 libreadtags_la_LDFLAGS = -no-undefined -version-info $(LT_VERSION)
+libreadtags_la_CFLAGS  = $(GCOV_CFLAGS)
 
 libreadtags_la_SOURCES = readtags.c readtags.h
 nobase_include_HEADERS = readtags.h

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,14 @@ AC_PROG_LIBTOOL
 # libtool -version-info
 AC_SUBST(LT_VERSION, [0:0:0])
 
+AC_ARG_ENABLE([gcov],
+	[AS_HELP_STRING([--enable-gcov],
+		[enable 'gcov' coverage testing tool [no]])])
+if test "${enable_gcov}" = "yes"; then
+	GCOV_CFLAGS="--coverage"
+fi
+AC_SUBST([GCOV_CFLAGS])
+
 AC_PROG_CC_C99
 
 AC_CONFIG_FILES([Makefile

--- a/readtags.h
+++ b/readtags.h
@@ -251,9 +251,9 @@ extern tagResult tagsFirstPseudoTag (tagFile *const file, tagEntry *const entry)
 extern tagResult tagsNextPseudoTag (tagFile *const file, tagEntry *const entry);
 
 /*
-*  Call tagsTerminate() at completion of reading the tag file, which will
+*  Call tagsClose() at completion of reading the tag file, which will
 *  close the file and free any internal memory allocated. The function will
-*  return TagFailure is no file is currently open, TagSuccess otherwise.
+*  return TagFailure if no file is currently open, TagSuccess otherwise.
 */
 extern tagResult tagsClose (tagFile *const file);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,6 +23,7 @@ check_PROGRAMS = \
 EXTRA_DIST =
 
 AM_CPPFLAGS = -I $(top_srcdir)
+AM_CFLAGS = $(GCOV_CFLAGS)
 DEPS = $(top_builddir)/libreadtags.la
 LDADD = $(top_builddir)/libreadtags.la
 


### PR DESCRIPTION
When --enable-gcov is passed to configure, gcov enabled libreadtags is built.

Usage:

	$ ./configure --enable-gcov
	$ make check
	$ gcov libreadtags_la-readtags.gcno -o .libs/
	$ less readtags.c.gcov

Signed-off-by: Masatake YAMATO <yamato@redhat.com>