### PR TITLE
Delete DEBUG output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Test
           command: |
-            make check
+            make check VERBOSE=1
   fedora31_distcheck:
     working_directory: ~/libreadtags
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,11 @@ test-driver
 
 tests/*.log
 tests/*.trs
+tests/test-api-tagsClose
 tests/test-api-tagsFind
 tests/test-api-tagsFirst
 tests/test-api-tagsFirstPseudoTag
 tests/test-api-tagsOpen
+tests/test-api-tagsSetSortType
 tests/test-fix-null-deref
 tests/test-fix-unescaping

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Version ???
+
+- delete debug output automatically printed when DEBUG is defiend in
+  build-time.
+
 # Version 0.1.0
 
 - propagate internal errors to caller

--- a/readtags.c
+++ b/readtags.c
@@ -1095,18 +1095,12 @@ static tagResult find (tagFile *const file, tagEntry *const entry,
 	if ((file->sortMethod == TAG_SORTED      && !file->search.ignorecase) ||
 		(file->sortMethod == TAG_FOLDSORTED  &&  file->search.ignorecase))
 	{
-#ifdef DEBUG
-		fputs ("<performing binary search>\n", stderr);
-#endif
 		result = findBinary (file);
 		if (result == TagFailure && file->err)
 			return TagFailure;
 	}
 	else
 	{
-#ifdef DEBUG
-		fputs ("<performing sequential search>\n", stderr);
-#endif
 		result = findSequential (file);
 		if (result == TagFailure && file->err)
 			return TagFailure;

--- a/tests/test-api-tagsOpen.c
+++ b/tests/test-api-tagsOpen.c
@@ -157,7 +157,8 @@ main (void)
 	}
 	fprintf (stderr, "ok\n");
 
-	fprintf (stderr, "opening a / (EISDIR is expected)...");
+	fprintf (stderr, "opening a / (an error is expected)...");
+	info.status.error_number = 0;
 	t = tagsOpen ("/", &info);
 	if (t != NULL)
 	{
@@ -169,12 +170,12 @@ main (void)
 		fprintf (stderr, "unexpected result (opened != 0)\n");
 		return 1;
 	}
-	else if (info.status.error_number != EISDIR)
+	else if (info.status.error_number == 0)
 	{
-		fprintf (stderr, "unexpected result (%d != EISDIR)\n", info.status.error_number);
+		fprintf (stderr, "no error\n");
 		return 1;
 	}
-	fprintf (stderr, "ok\n");
+	fprintf (stderr, "ok (errno: %d)\n", info.status.error_number);
 
 	fprintf (stderr, "closing the unopened tag file...");
 	if (tagsClose (t) == TagSuccess)

--- a/tests/test-api-tagsOpen.c
+++ b/tests/test-api-tagsOpen.c
@@ -171,7 +171,7 @@ main (void)
 	}
 	else if (info.status.error_number != EISDIR)
 	{
-		fprintf (stderr, "unexpected result (error_number != EISDIR)\n");
+		fprintf (stderr, "unexpected result (%d != EISDIR)\n", info.status.error_number);
 		return 1;
 	}
 	fprintf (stderr, "ok\n");


### PR DESCRIPTION
When DEBUG is defiend at build-time, the debug output is enabled.  It
cannot be disabled at run-time. As a result, the outputs can be just
noise when testing a command using libreadtags like ctags.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>