### PR TITLE
Add _WIN64 preprocessor to use _ftelli64 and _fseeki64

### DIFF
--- a/readtags.c
+++ b/readtags.c
@@ -9,8 +9,8 @@
 /*
 *   INCLUDE FILES
 */
-#ifdef _WIN32
-#include <config.h>  /* to define _FILE_OFFSET_BITS for Windows */
+#if defined(_WIN32) && !defined(_FILE_OFFSET_BITS)
+#define _FILE_OFFSET_BITS 64
 #endif
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Add `_ftelli64` and `_fseeki64` to fix https://github.com/universal-ctags/libreadtags/issues/36.

Note to properly use 8-byte `off_t`, the header `config.h` is included on Windows. Since `_mingw_off_t.h` (it is included in `stdio.h`)  is defined as:

``` C
#ifndef _OFF_T_DEFINED
#define _OFF_T_DEFINED
#ifndef _OFF_T_
#define _OFF_T_
  typedef long _off_t;
#if !defined(NO_OLDNAMES) || defined(_POSIX)
  typedef long off32_t;
#endif
#endif

#ifndef _OFF64_T_DEFINED
#define _OFF64_T_DEFINED
  __MINGW_EXTENSION typedef long long _off64_t;
#if !defined(NO_OLDNAMES) || defined(_POSIX)
  __MINGW_EXTENSION typedef long long off64_t;
#endif
#endif /*_OFF64_T_DEFINED */


#ifndef _FILE_OFFSET_BITS_SET_OFFT
#define _FILE_OFFSET_BITS_SET_OFFT
#if !defined(NO_OLDNAMES) || defined(_POSIX)
#if (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64))
typedef off64_t off_t;
#else
typedef off32_t off_t;
#endif /* #if !defined(NO_OLDNAMES) || defined(_POSIX) */
#endif /* (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)) */
#endif /* _FILE_OFFSET_BITS_SET_OFFT */


#endif /* _OFF_T_DEFINED */

```

Note this PR is only tested on Windows and built from mingw64.