### PR TITLE
tests: report failure if TagErrnoFileMaybeTooBig is set

### DIFF
--- a/tests/test-fix-large-tags.c
+++ b/tests/test-fix-large-tags.c
@@ -123,7 +123,10 @@ main (void)
 		 && (
 			 info.status.error_number == EFBIG
 			 || info.status.error_number == TagErrnoFileMaybeTooBig)))
-		fprintf(stderr, "failed with expected error\n");
+	{
+		r = 1;
+		fprintf(stderr, "failed with expected error: %d\n", info.status.error_number);
+	}
 	else if (t && info.status.opened)
 		fprintf(stderr, "done\n");
 	else


### PR DESCRIPTION
The original code reported "successfully" when TagErrnoFileMaybeTooBig
was set.

Now libreadtags supports big tags file (> 2G) on Win32 platform,
TagErrnoFileMaybeTooBig should be reported as a failure.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>