### PR TITLE
 Use mmap(2) when opening a tags file if fopen() supports "m" mode flag.

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -50,3 +50,5 @@ jobs:
     - run: make check V=1
     - run: cat tests/test-suite.log
       if: failure()
+    - run: for x in tests/*.log; do echo '#' $x; cat $x; done
+      if: failure()

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 - add a new API function (tagsFindPseudoTag) for finding a pseudo tag for
   given name.
 
+- Use mmap(2) when opening a tags file if fopen() supports "m" mode flag.
+
 # Version 0.1.0
 
 - propagate internal errors to caller

--- a/readtags.c
+++ b/readtags.c
@@ -832,7 +832,14 @@ static tagFile *initialize (const char *const filePath, tagFileInfo *const info)
 		result->fields.max, sizeof (tagExtensionField));
 	if (result->fields.list == NULL)
 		goto mem_error;
-	result->fp = fopen (filePath, "rb");
+
+#define GLIBC_FOPEN_MODE_USE_MMAP "m"
+	result->fp = fopen (filePath, "rb" GLIBC_FOPEN_MODE_USE_MMAP);
+	if (result->fp == NULL)
+	{
+		errno = 0;
+		result->fp = fopen (filePath, "rb");
+	}
 	if (result->fp == NULL)
 	{
 		info->status.error_number = errno;


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>