### PR TITLE
Put inline keyword on a hot spot function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,23 @@ set(API_VERSION 1)
 # that is built with Autotools.
 set(BUILD_VERSION 1.1.2)
 
+# Taken from https://gitlab.kitware.com/cmake/community/-/wikis/contrib/macros/TestInline
+# Inspired from /usr/share/autoconf/autoconf/c.m4
+foreach(KEYWORD "inline" "__inline__" "__inline")
+  if(NOT DEFINED C_INLINE)
+    try_compile(C_HAS_${KEYWORD} "${CMAKE_CURRENT_BINARY_DIR}"
+      "${CMAKE_CURRENT_SOURCE_DIR}/test_inline.c"
+      COMPILE_DEFINITIONS "-Dinline=${KEYWORD}")
+    if(C_HAS_${KEYWORD})
+      SET(C_INLINE TRUE)
+      ADD_DEFINITIONS("-Dinline=${KEYWORD}")
+    endif(C_HAS_${KEYWORD})
+  endif(NOT DEFINED C_INLINE)
+endforeach(KEYWORD)
+if(NOT DEFINED C_INLINE)
+  ADD_DEFINITIONS("-Dinline=")
+endif(NOT DEFINED C_INLINE)
+
 if (LIBREADTAGS_BUILD_SHARED)
     message(STATUS "Building shared library")
     add_library(${PROJECT_NAME} SHARED readtags.c)

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 AM_CFLAGS=-Wall
 
-EXTRA_DIST = README.md NEWS.md CMakeLists.txt
+EXTRA_DIST = README.md NEWS.md CMakeLists.txt test_inline.c
 
 lib_LTLIBRARIES    = libreadtags.la
 libreadtags_la_LDFLAGS = -no-undefined -version-info $(LT_VERSION)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# Version XXX
+
+- imporve performance; put inline keyword on a hot spot function.
+
+	- before this change
+
+		```
+		$ /bin/time ./readtags -t ~/.citre/kernel82.tags -l > /dev/null
+		9.59user 0.42system 0:10.06elapsed 99%CPU (0avgtext+0avgdata 2819340maxresident)k
+		0inputs+0outputs (0major+44149minor)pagefaults 0swaps
+		```
+
+	- after this change
+
+		```
+		$ /bin/time ./readtags -t ~/.citre/kernel82.tags -l > /dev/null
+		7.82user 0.43system 0:08.30elapsed 99%CPU (0avgtext+0avgdata 2819688maxresident)k
+		0inputs+0outputs (0major+44138minor)pagefaults 0swaps
+		```
+
 # Version 0.4.0
 
 - support cmake as a build system (ParticleG <particle_g@outlook.com>)

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ fi
 AC_SUBST([GCOV_CFLAGS])
 
 AC_PROG_CC_C99
+AC_C_INLINE
 
 AC_CONFIG_FILES([Makefile
 		libreadtags.pc

--- a/readtags.c
+++ b/readtags.c
@@ -151,6 +151,7 @@ static int xdigitValue (unsigned char digit)
  * Reads the first character from the string, possibly un-escaping it, and
  * advances *s to the start of the next character.
  */
+inline
 static int readTagCharacter (const char **const s)
 {
 	const unsigned char *p = (const unsigned char *) *s;

--- a/test_inline.c
+++ b/test_inline.c
@@ -1,0 +1,7 @@
+/* Taken from  https://gitlab.kitware.com/cmake/community/-/wikis/contrib/macros/TestInline
+ * for using "inline" with cmake build. */
+/* Test source lifted from /usr/share/autoconf/autoconf/c.m4 */
+typedef int foo_t;
+static inline foo_t static_foo(){return 0;}
+foo_t foo(){return 0;}
+int main(int argc, char *argv[]){return 0;}


### PR DESCRIPTION
Before this change:

	$ /bin/time ./readtags -t ~/.citre/kernel82.tags -l > /dev/null
	9.59user 0.42system 0:10.06elapsed 99%CPU (0avgtext+0avgdata 2819340maxresident)k
	0inputs+0outputs (0major+44149minor)pagefaults 0swaps

After this change:

	$ /bin/time ./readtags -t ~/.citre/kernel82.tags -l > /dev/null
	7.82user 0.43system 0:08.30elapsed 99%CPU (0avgtext+0avgdata 2819688maxresident)k
	0inputs+0outputs (0major+44138minor)pagefaults 0swaps